### PR TITLE
Some requirements changes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,17 @@ Written in C++, it requires the following to compile:
 
 This program has been verified to compile on Ubuntu 14.04 with gcc 4.8.2 (standard on ubuntu)
 
-#### gcc on Ubuntu 14.04
-	sudo apt-get install gcc
+#### gcc + g++ on Ubuntu 14.04
+	sudo apt-get install g++
 
 #### tcmalloc on Ubuntu 14.04
 	sudo apt-get install libtcmalloc-minimal4
 	cd /usr/lib
 	sudo ln -s libtcmalloc.so.4 libtcmalloc.so
+#    Alternatively you can install the full gperftools suite which includes tcmalloc
 
 #### Scons on Ubuntu 14.04
-	sudo apt-get install scons duplicity
+	sudo apt-get install scons
 
 #### Boost on Ubuntu 14.04
 	sudo apt-get install libboost-all-dev


### PR DESCRIPTION
As I have a fresh ubuntu laptop I noticed some details some users, particulary new ones, may run into.

Chunk # 1. I'm accustomed to the gcc package including g++ too, but on Ubuntu 14.04 I had to install g++ additionally before building the driver.
Chunk # 2. just a note to save gperftools users from installing libtcmalloc again unnecessarily
Chunk # 3. Is duplicity required? I know it as backup tool and I see it's installed by default on my new ubuntu build, but I don't think scons has a requirement.
