### PR TITLE
Adding field name in appendNull()

### DIFF
--- a/src/parserapidjsonevents.h
+++ b/src/parserapidjsonevents.h
@@ -78,7 +78,7 @@ public:
     bool Null() {
         switch (_state) {
         case Value:
-            _bob->appendNull();
+            _bob->appendNull(_field);
             _state = Field;
             return true;
         default:


### PR DESCRIPTION
When importing a json document with null-value fields mlightning can throw "Invalid call to appendNull in BSONObj Builder". It seems any "foo": null value anywhere can cause that.

In parserapidjsonevents.h I found the argument-less version of appendNull was being used, and all it does is throw an assertion. Avoided by using the version that accepts a field name as a single string arg.
